### PR TITLE
Use Peer Dependencies

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: [require.resolve('./index')]
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.eslintcache

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -2,6 +2,11 @@
   "extends": [
     "prettier/react"
   ],
+
+  "plugins": [
+    "react"
+  ],
+
   "rules": {
     "react/jsx-boolean-value": 2,
     "react/jsx-key": 2,

--- a/package.json
+++ b/package.json
@@ -3,8 +3,12 @@
   "version": "3.0.0",
   "description": "An ESLint configuration for SeatGeek's React code.",
   "main": "index.js",
+  "files": [
+    "eslintrc.json",
+    "index.js"
+  ],
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "eslint . --cache"
   },
   "repository": {
     "type": "git",
@@ -15,15 +19,21 @@
     "configuration"
   ],
   "author": "Gareth Tan (http://garethtan.com/)",
-  "license": "BSD2",
+  "license": "BSD-2-Clause",
   "bugs": {
     "url": "https://github.com/seatgeek/eslint-config-seatgeek-react-standard/issues"
   },
   "homepage": "https://github.com/seatgeek/eslint-config-seatgeek-react-standard",
-  "dependencies": {
-    "eslint": "3.19.0",
-    "eslint-plugin-prettier": "2.0.1",
-    "eslint-plugin-react": "6.10.3",
-    "prettier": "1.0.2"
+  "peerDependencies": {
+    "eslint": "^4.8.0",
+    "eslint-config-prettier": "^2.6.0",
+    "eslint-plugin-react": "^7.4.0",
+    "prettier": "^1.7.4"
+  },
+  "devDependencies": {
+    "eslint": "^4.8.0",
+    "eslint-config-prettier": "^2.6.0",
+    "eslint-plugin-react": "^7.4.0",
+    "prettier": "^1.7.4"
   }
 }


### PR DESCRIPTION
Summary
--
Several of us (including @egeriis and myself) have found that with Yarn v1, our ESLint config packages no longer work properly in the seatgeek/seatgeek repo. The root cause appears to be that Yarn is nesting node modules slightly differently, specifically the various ESLint plugins and configs that this package depends on. ESLint can only resolve plugins and configs from the very root `node_modules` directory, so it's unable to find the plugins now that they're getting nested in `node_modules/eslint-config-seatgeek-react-standard/node_modules`. See https://github.com/seatgeek/tixcast/issues/20515

Most shared ESLint package specify any plugin dependencies as `peerDependencies` for this very reason. While it makes installation a bit more annoying, updating to `peerDependencies` will give us more reliable installs.

I updated to the latest versions of all the plugins here and added a simple test that simply extends this config and verifies ESLint can run successfully.

This should be released as version `4.0.0` since it's a breaking change.